### PR TITLE
fix: prevent monster hit with critical damage + fix critical in pvp

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2554,6 +2554,7 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 
       if (targets.size() == 1) {
           damage = targets.front()->getCombatDamage();
+			}
 	}
 }
 


### PR DESCRIPTION
Fix the error when a player hits another player without target selection; the critical hit was not being applied. With this script correction, the damage is applied both in single-target and area attacks, without applying critical damage when monsters attack the same player.